### PR TITLE
[WIP] Updating SNAP submodule for compatibility with newer versions of LAMMPS

### DIFF
--- a/mlearn/describers.py
+++ b/mlearn/describers.py
@@ -21,7 +21,7 @@ class BispectrumCoefficients(BaseEstimator, MSONable, TransformerMixin):
     """
 
     def __init__(self, rcutfac, twojmax, element_profile, rfac0=0.99363,
-                 rmin0=0, diagonalstyle=3, quadratic=False, pot_fit=False):
+                 rmin0=0, quadratic=False, pot_fit=False):
         """
 
         Args:
@@ -35,9 +35,6 @@ class BispectrumCoefficients(BaseEstimator, MSONable, TransformerMixin):
                 Set between (0, 1), default to 0.99363.
             rmin0 (float): Parameter in distance to angle conversion.
                 Default to 0.
-            diagonalstyle (int): Parameter defining which bispectrum
-                components are generated. Choose among 0, 1, 2 and 3,
-                default to 3.
             quadratic (bool): Whether including quadratic terms.
                 Default to False.
             pot_fit (bool): Whether to output in potentials fitting
@@ -49,14 +46,12 @@ class BispectrumCoefficients(BaseEstimator, MSONable, TransformerMixin):
         self.calculator = SpectralNeighborAnalysis(rcutfac, twojmax,
                                                    element_profile,
                                                    rfac0, rmin0,
-                                                   diagonalstyle,
                                                    quadratic)
         self.rcutfac = rcutfac
         self.twojmax = twojmax
         self.element_profile = element_profile
         self.rfac0 = rfac0
         self.rmin0 = rmin0
-        self.diagonalstyle = diagonalstyle
         self.elements = sorted(element_profile.keys(),
                                key=lambda sym: get_el_sp(sym).X)
         self.quadratic = quadratic
@@ -69,8 +64,7 @@ class BispectrumCoefficients(BaseEstimator, MSONable, TransformerMixin):
         involved.
 
         """
-        return self.calculator.get_bs_subscripts(self.twojmax,
-                                                 self.diagonalstyle)
+        return self.calculator.get_bs_subscripts(self.twojmax)
 
     def describe(self, structure, include_stress=False):
         """

--- a/mlearn/models.py
+++ b/mlearn/models.py
@@ -6,7 +6,7 @@
 
 import warnings
 from monty.json import MSONable
-from sklearn.externals import joblib
+import joblib
 from sklearn.base import BaseEstimator
 from sklearn.gaussian_process import kernels
 from sklearn.gaussian_process import GaussianProcessRegressor

--- a/mlearn/potentials/snap.py
+++ b/mlearn/potentials/snap.py
@@ -21,7 +21,7 @@ class SNAPotential(Potential):
     """
 
     pair_style = 'pair_style        snap'
-    pair_coeff = 'pair_coeff        * * {coeff_file} {elements} {param_file} {specie}'
+    pair_coeff = 'pair_coeff        * * {coeff_file} {param_file} {elements} {specie}'
 
     def __init__(self, model, name=None):
         """
@@ -130,7 +130,7 @@ class SNAPotential(Potential):
             f.write('\n'.join(coeff_lines))
 
         param_lines = []
-        keys = ['rcutfac', 'twojmax', 'rfac0', 'rmin0', 'diagonalstyle']
+        keys = ['rcutfac', 'twojmax', 'rfac0', 'rmin0']
         param_lines.extend(['{} {}'.format(k, getattr(describer, k))
                             for k in keys])
         param_lines.append('quadraticflag {}'.format(int(describer.quadratic)))
@@ -181,7 +181,6 @@ class SNAPotential(Potential):
         twojmax_pattern = re.compile(r'twojmax (\d*)\n', re.S)
         rfac_pattern = re.compile(r'rfac0 (.*?)\n', re.S)
         rmin_pattern = re.compile(r'rmin0 (.*?)\n', re.S)
-        diagonalstyle_pattern = re.compile(r'diagonalstyle (.*?)\n', re.S)
         quadratic_pattern = re.compile(r'quadraticflag (.*?)(?=\n|$)', re.S)
 
         with zopen(param_file, 'rt') as f:
@@ -191,7 +190,6 @@ class SNAPotential(Potential):
         twojmax = int(twojmax_pattern.findall(param_lines)[-1])
         rfac = float(rfac_pattern.findall(param_lines)[-1])
         rmin = int(rmin_pattern.findall(param_lines)[-1])
-        diagonal = int(diagonalstyle_pattern.findall(param_lines)[-1])
         if quadratic_pattern.findall(param_lines):
             quadratic = bool(int(quadratic_pattern.findall(param_lines)[-1]))
         else:
@@ -199,7 +197,7 @@ class SNAPotential(Potential):
 
         describer = BispectrumCoefficients(rcutfac=rcut, twojmax=twojmax,
                                            rfac0=rfac, element_profile=element_profile,
-                                           rmin0=rmin, diagonalstyle=diagonal, quadratic=quadratic,
+                                           rmin0=rmin, quadratic=quadratic,
                                            pot_fit=True)
         model = LinearModel(describer=describer, **kwargs)
         model.model.coef_ = np.array(coeff_lines[2:], dtype=np.float)


### PR DESCRIPTION
The SNAP examples need a few minor adjustments to be compatible with newer versions of LAMMPS (2019-).

- `compute b all sna/atom` cannot be ran with the diagonal keyword. [It has been removed from LAMMPS.](https://lammps.sandia.gov/doc/compute_sna_atom.html)
- `pair_coeff` needs to be [reordered](https://lammps.sandia.gov/doc/pair_snap.html) such that element mappings are grouped at the end.

I have ran `test_snap.py`, which passes 3 of the 4 tests after these changes. The fourth test, `test_from_config`, also passes when `coeff_file` and `param_file` are modified to point to the `mlearn/notebooks/examples/SNAP_example` files, but I do not know how to write that as a relative path.

The joblib import also needs to be modified because it is now a standalone package and no longer included with scikit-learn.